### PR TITLE
fix: lower Sonar Plugin API baseline to 11.1.0.2693 for broader compa…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.1] - 2026-06-09
+
+### Changed
+- Lowered the Sonar Plugin API baseline from `13.5.0.4319` to `11.1.0.2693` to broaden SonarQube compatibility. The plugin now loads on SonarQube Server 2025.1.x LTA (Plugin API 11.x) as well as newer Community Build releases (e.g. 25.9, Plugin API 13.x).
+- Aligned the test-scoped `sonar-plugin-api-impl` to `25.2.0.102705` to match the new API baseline.
+
 ## [2.0.0] - 2026-05-06
 
 ### Added

--- a/asyncapi-checks/pom.xml
+++ b/asyncapi-checks/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.apiaddicts.apitools.dosonarapi</groupId>
     <artifactId>dosonarapi-asyncapi</artifactId>
-    <version>2.0.0</version>
+    <version>2.0.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/asyncapi-front-end/pom.xml
+++ b/asyncapi-front-end/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.apiaddicts.apitools.dosonarapi</groupId>
     <artifactId>dosonarapi-asyncapi</artifactId>
-    <version>2.0.0</version>
+    <version>2.0.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/asyncapi-test-tools/pom.xml
+++ b/asyncapi-test-tools/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.apiaddicts.apitools.dosonarapi</groupId>
     <artifactId>dosonarapi-asyncapi</artifactId>
-    <version>2.0.0</version>
+    <version>2.0.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/its/pom.xml
+++ b/its/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.apiaddicts.apitools.dosonarapi</groupId>
         <artifactId>dosonarapi-asyncapi</artifactId>
-        <version>2.0.0</version>
+        <version>2.0.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
   <groupId>org.apiaddicts.apitools.dosonarapi</groupId>
   <artifactId>dosonarapi-asyncapi</artifactId>
-  <version>2.0.0</version>
+  <version>2.0.1</version>
   <packaging>pom</packaging>
 
   <name>SonarAsyncAPI</name>
@@ -73,8 +73,8 @@
     <commons.lang.version>2.6</commons.lang.version>
     <junit.version>4.13.2</junit.version>
     <mockito.version>5.23.0</mockito.version>
-    <sonar.version>13.5.0.4319</sonar.version>
-    <sonar.impl.version>26.4.0.121862</sonar.impl.version>
+    <sonar.version>11.1.0.2693</sonar.version>
+    <sonar.impl.version>25.2.0.102705</sonar.impl.version>
     <sonar.analyzer.commons.version>2.22.0.4796</sonar.analyzer.commons.version>
     <sonar.orchestrator.version>6.1.0.3962</sonar.orchestrator.version>
     <sslr.version>1.25.1.3886</sslr.version>

--- a/sonar-asyncapi-plugin/pom.xml
+++ b/sonar-asyncapi-plugin/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.apiaddicts.apitools.dosonarapi</groupId>
     <artifactId>dosonarapi-asyncapi</artifactId>
-    <version>2.0.0</version>
+    <version>2.0.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

The plugin is compiled against Sonar Plugin API `13.5.0.4319`, so the JAR manifest requires the SonarQube server to provide API >= 13.5. On servers running an older API, the plugin is rejected at startup:

​```
Plugin AsyncAPI Custom [asyncapicustom] requires at least Sonar Plugin API version 13.5.0.4319 (current: 13.0.0.3026)
​```

This prevents the plugin from loading on SonarQube Server 2025.1.x LTA (Plugin API 11.x), e.g. Enterprise Edition 2025.1.3.

Issue Number: N/A

## What is the new behavior?

- Lowers the Sonar Plugin API baseline from `13.5.0.4319` to `11.1.0.2693` (the 2025.1.0 LTA baseline), so the plugin loads on the whole 2025.1.x LTA line (Plugin API 11.x) and also on newer Community Builds (25.8/25.9, Plugin API 13.x) thanks to backward compatibility.
- Aligns `sonar-plugin-api-impl` (test scope) to `25.2.0.102705`, the Community Build that pairs with API 11.1, so the test harness matches the new baseline.
- Bumps the version `2.0.0` → `2.0.1` across all modules and adds the CHANGELOG entry.

## Other information

Verification performed:
- `mvn clean test` → BUILD SUCCESS, all tests pass.
- The generated JAR manifest reports `Sonar-Version: 11.1.0.2693`.
- The code compiles against API 11.x (no APIs exclusive to 12.x/13.x are used). `sonar-analyzer-commons` (shaded) verified working on API 11.x in the tests.
- Dependency tree with no version conflicts; `sonar-plugin-api` resolves uniquely to `11.1.0.2693`.

Compatibility rule applied: *plugin's required API ≤ API provided by the server*. Building against the oldest API that still compiles maximizes compatibility without losing functionality (the plugin did not use anything newer than 11.1).
